### PR TITLE
Fix ArduinoISP sketch for Uno WiFi Rev2

### DIFF
--- a/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
+++ b/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
@@ -54,10 +54,10 @@
 
 
 // Select hardware or software SPI, depending on SPI clock.
-// Currently only for AVR, for other architectures (Due, Zero,...), hardware SPI
+// Currently only for AVR and megaAVR, for other architectures (Due, Zero,...), hardware SPI
 // is probably too fast anyway.
 
-#if defined(ARDUINO_ARCH_AVR)
+#if defined(ARDUINO_ARCH_AVR) | defined(ARDUINO_ARCH_MEGAAVR)
 
   #if SPI_CLOCK > (F_CPU / 128)
     #define USE_HARDWARE_SPI


### PR DESCRIPTION
When using bit banged SPI, which the sketch did when compiled for any architecture other than AVR, a `SPISettings` class was declared by the sketch. At the time the sketch was written, it was reasonable to expect this would not cause a name collision, since SPI.h is not `#include`d when doing bit banged SPI. However, since then a `SPISettings` class has been declared in [ArduinoCore-API's HardwareSPI.h](https://github.com/arduino/ArduinoCore-API/blob/932c7c7d4d4d334b10484284cc846672ad59607c/api/HardwareSPI.h#L37), causing the ArduinoISP sketch to [not compile](https://github.com/arduino/arduino-examples/runs/1054255585?check_suite_focus=true#step:4:251) for any board whose core uses ArduinoCoreAPI (currently [Arduino Mega AVR Boards](https://github.com/arduino/ArduinoCore-megaavr), "[Arduino nRF528x Boards (Mbed OS](https://github.com/arduino/ArduinoCore-nRF528x-mbedos))", and "[Arduino Mbed OS Boards (nRF52840 / STM32H747)](https://github.com/arduino/ArduinoCore-mbed)"):

```
  /github/workspace/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino:191:27: error: reference to 'SPISettings' is ambiguous
       void beginTransaction(SPISettings settings) {
                             ^~~~~~~~~~~
  /github/workspace/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino:167:7: note: candidates are: class SPISettings
   class SPISettings {
         ^~~~~~~~~~~
  In file included from /github/home/.arduino15/packages/arduino/hardware/megaavr/1.8.6/cores/arduino/api/ArduinoAPI.h:31:0,
                   from /github/home/.arduino15/packages/arduino/hardware/megaavr/1.8.6/cores/arduino/Arduino.h:23,
                   from /github/workspace/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino:39:
  /github/home/.arduino15/packages/arduino/hardware/megaavr/1.8.6/cores/arduino/api/HardwareSPI.h:37:7: note:                 class arduino::SPISettings
   class SPISettings {
         ^~~~~~~~~~~
```

Although it's easy enough to fix the name collision (https://github.com/arduino/arduino-examples/pull/3), it seemed a better idea to simply use hardware SPI when compiling for the megaAVR architecture.

---
After this change, I was able to use the Uno WiFi Rev2 as an "Arduino as ISP" programmer with "Burn Bootloader" and "Upload Using Programmer". It is necessary to use the **Tools > Programmer > Arduino as ISP (ATmega32U4)**.

---
Unfortunately, I found that, although the sketch compiles, I still can't use the Nano Every as an "Arduino as ISP" programmer. It is able to read the chip signature and read and write fuses, but there are `avrdude: stk500_recv(): programmer is not responding` errors while writing the program to flash.

I found that the same issue occurs if I use the Nano Every and Nano 33 BLE with the bit banged SPI code (after fixing the name collision), while the Uno WiFi Rev2 works fine with the bit banged SPI.