### PR TITLE
Remove compilations that fail due to bugs in external components from "Compile Examples" CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -65,7 +65,8 @@ jobs:
         "examples/04.Communication/SerialEvent"
         "examples/04.Communication/VirtualColorMixer"
         "examples/05.Control"
-        "examples/06.Sensors"
+        "examples/06.Sensors/ADXL3xx"
+        "examples/06.Sensors/Knock"
         "examples/07.Display"
         "examples/08.Strings"
         "examples/11.ArduinoISP"
@@ -81,38 +82,47 @@ jobs:
             serial1: false
             starter-kit: true
             tone: true
+            pulsein: true
           # Adding this in addition to the Uno because it has 1.5 kB less available flash
           - fqbn: arduino:avr:nano
             usb: false
             serial1: false
             starter-kit: false
             tone: true
+            pulsein: true
           - fqbn: arduino:avr:leonardo
             usb: true
             serial1: true
             starter-kit: false
             tone: true
+            pulsein: true
           - fqbn: arduino:megaavr:uno2018:mode=off
             usb: false
             serial1: true
             starter-kit: false
             tone: true
+            pulsein: true
           - fqbn: arduino:samd:mkrzero
             usb: true
             serial1: true
             starter-kit: false
             tone: true
+            pulsein: true
           - fqbn: arduino:mbed:nano33ble
             usb: false
             serial1: true
             starter-kit: false
             tone: true
+            pulsein: true
           # Change this to arduino:mbed:envie_m7 once there is a production release of the Arduino Mbed OS Boards platform
           - fqbn: arduino-beta:mbed:envie_m7
             usb: false
             serial1: true
             starter-kit: false
             tone: true
+            # Bug report: https://github.com/arduino/ArduinoCore-mbed/issues/48
+            # Change the value to true once it is fixed.
+            pulsein: false
           - fqbn: arduino:sam:arduino_due_x
             usb: true
             serial1: true
@@ -120,6 +130,7 @@ jobs:
             # Bug report: https://github.com/arduino/ArduinoCore-sam/issues/24
             # Change the value to true once it is fixed.
             tone: false
+            pulsein: true
 
         # Make board type-specific customizations to the matrix jobs
         include:
@@ -163,6 +174,14 @@ jobs:
           - board:
               tone: false
             tone-sketch-paths: ""
+          - board:
+              pulsein: true
+            pulsein-sketch-paths: >-
+              "examples/06.Sensors/Memsic2125"
+              "examples/06.Sensors/Ping"
+          - board:
+              pulsein: false
+            pulsein-sketch-paths: ""
 
     steps:
       - name: Checkout
@@ -181,5 +200,6 @@ jobs:
             ${{ matrix.serial1-sketch-paths }}
             ${{ matrix.starter-kit-sketch-paths }}
             ${{ matrix.tone-sketch-paths }}
+            ${{ matrix.pulsein-sketch-paths }}
           # This input can be removed once the repository is made public
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Common functions of the standardized Arduino core API used by the example sketches have not been implemented in the core libraries of for some of the active official boards the Compile Examples workflow tests compilation of the example sketches for.

- `pulseIn()` missing for Portenta H7 (https://github.com/arduino/ArduinoCore-mbed/issues/48)
- `tone()` missing for Due (https://github.com/arduino/ArduinoCore-sam/issues/24)

Once these functions have been implemented and a release of the platform made containing that implementation, the commits removing the compillations should be reverted.

This procedure is documented in a comment at the top of the Compile Examples workflow configuration file.