### PR TITLE
Revert "Provide GitHub token to action in Compile Examples CI workflow"

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -201,5 +201,3 @@ jobs:
             ${{ matrix.starter-kit-sketch-paths }}
             ${{ matrix.tone-sketch-paths }}
             ${{ matrix.pulsein-sketch-paths }}
-          # This input can be removed once the repository is made public
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 50228bf858cb4d68978d72df1e9ee02e6e06dba8.

The GitHub access token was only required by the CI workflow while the repository was private. Now that it's been made public, there is no need for it any more.