### PR TITLE
Update 04.Analog/Calibrate.ino

### DIFF
--- a/examples/03.Analog/Calibration/Calibration.ino
+++ b/examples/03.Analog/Calibration/Calibration.ino
@@ -18,6 +18,8 @@
   by David A Mellis
   modified 30 Aug 2011
   by Tom Igoe
+  modified 07 Apr 2017
+  by Zachary J. Fields
 
   This example code is in the public domain.
 
@@ -62,11 +64,11 @@ void loop() {
   // read the sensor:
   sensorValue = analogRead(sensorPin);
 
+  // in case the sensor value is outside the range seen during calibration
+  sensorValue = constrain(sensorValue, sensorMin, sensorMax);
+
   // apply the calibration to the sensor reading
   sensorValue = map(sensorValue, sensorMin, sensorMax, 0, 255);
-
-  // in case the sensor value is outside the range seen during calibration
-  sensorValue = constrain(sensorValue, 0, 255);
 
   // fade the LED using the calibrated value:
   analogWrite(ledPin, sensorValue);


### PR DESCRIPTION
*Moved from https://github.com/arduino/Arduino/pull/6159 by @zfields*

Calibrate generated values beyond the from range of the map function and the behavior did not seem to match the spirit of the comments.