### PR TITLE
Expand String examples with explicit size concat and constructor

### DIFF
--- a/examples/08.Strings/StringAppendOperator/StringAppendOperator.ino
+++ b/examples/08.Strings/StringAppendOperator/StringAppendOperator.ino
@@ -67,6 +67,23 @@ void loop() {
   stringTwo.concat(millis());
   Serial.println(stringTwo); // prints "The millis(): 43534" or whatever the value of the millis() is
 
+  #if ARDUINO_API_VERSION >= 10000
+  // using concat with an explicit length argument to add only a part of
+  // a string:
+  stringOne = "Only part: ";
+  char *to_add = "use this but not this";
+  stringOne.concat(to_add, 8);
+  Serial.println(stringOne);   // prints "Only part: use this"
+
+  // using concat with an explicit length argument to add a
+  // non-zero-terminated string / char array (note that it will be
+  // terminated inside the String object).
+  stringTwo = "Unterminated: ";
+  char unterminated[] = {'n', 'o', 'n', 'u', 'l'};
+  stringTwo.concat(unterminated, sizeof(unterminated));
+  Serial.println(stringTwo); // prints "Unterminated: nonul"
+  #endif // ARDUINO_API_VERSION
+
   // do nothing while true:
   while (true);
 }

--- a/examples/08.Strings/StringConstructors/StringConstructors.ino
+++ b/examples/08.Strings/StringConstructors/StringConstructors.ino
@@ -74,6 +74,21 @@ void loop() {
   stringOne = String(5.698, 2);
   Serial.println(stringOne);
 
+  #if ARDUINO_API_VERSION >= 10000
+  // Using an explicit length argument to to use only a part of a
+  // string:
+  char *to_add = "use this but not this";
+  stringOne = String(to_add, 8);
+  Serial.println(stringOne);   // prints "use this"
+
+  // using explicit length argument to add a non-zero-terminated string
+  // / char array (note that it will be terminated inside the String
+  // object).
+  char unterminated[] = {'n', 'o', 'n', 'u', 'l'};
+  stringTwo = String(unterminated, sizeof(unterminated));
+  Serial.println(stringTwo); // prints "nonul"
+  #endif // ARDUINO_API_VERSION
+
   // do nothing while true:
   while (true);
 


### PR DESCRIPTION
*Moved from https://github.com/arduino/Arduino/pull/9239 by @matthijskooijman*

This expands examples to show the newly added APIs:

	String::concat(const char *, unsigned int)
	String::String(const char *, unsigned int)

Since not all cores versions will support this right away, a version
check is added against ARDUINO_CORE_API.

These APIs are added to ArduinoCore-API in https://github.com/arduino/ArduinoCore-API/pull/97. Before merging these examples, the version check must be updated to the first API version that includes these new APIs.