### PR TITLE
Update FQBN for Portenta H7 in Compile Examples CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -114,8 +114,7 @@ jobs:
             starter-kit: false
             tone: true
             pulsein: true
-          # Change this to arduino:mbed:envie_m7 once there is a production release of the Arduino Mbed OS Boards platform
-          - fqbn: arduino-beta:mbed:envie_m7
+          - fqbn: arduino:mbed:envie_m7
             usb: false
             serial1: true
             starter-kit: false


### PR DESCRIPTION
The beta phase arduino-beta:mbed boards platform of the Portenta H7 has been deprecated, which will cause the compilation check CI for this board to fail when the old FQBN is used.

Reference: https://github.com/arduino/ArduinoCore-mbed/issues/72