### PR TITLE
Restrict ArduinoISP name collision fix to ArduinoCore-API 1.0.1

### DIFF
--- a/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
+++ b/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
@@ -164,7 +164,7 @@ void pulse(int pin, int times);
 
 #define SPI_MODE0 0x00
 
-#if !defined(ARDUINO_API_VERSION) // A SPISettings class is declared by ArduinoCore-API
+#if !defined(ARDUINO_API_VERSION) || ARDUINO_API_VERSION != 10001 // A SPISettings class is declared by ArduinoCore-API 1.0.1
 class SPISettings {
   public:
     // clock is in Hz


### PR DESCRIPTION
ArduinoCore-API 1.0.1 declares a `SPISettings` class:
https://github.com/arduino/ArduinoCore-API/blob/7c9e4f8abde3ce75234e51c0e5be3083832c3e49/api/ArduinoAPI.h#L31
but ArduinoCore-API 1.0.0 and 1.1.0 don't do this:
- https://github.com/arduino/ArduinoCore-API/blob/1.0.0/api/ArduinoAPI.h
- https://github.com/arduino/ArduinoCore-API/blob/1.1.0/api/ArduinoAPI.h (https://github.com/arduino/ArduinoCore-API/pull/120)
So the previous preprocessor conditional that was added to fix the ArduinoCore-API sketch for platforms using ArduinoCore-API 1.0.1 actually breaks it for platforms using previous or later versions.

Reference: https://github.com/arduino/arduino-examples/commit/b94e757d7a0c50ffb32c225019197bb387978fee#r44269343