### PR TITLE
Changing Tutorial's link

### DIFF
--- a/examples/02.Digital/StateChangeDetection/StateChangeDetection.ino
+++ b/examples/02.Digital/StateChangeDetection/StateChangeDetection.ino
@@ -21,7 +21,7 @@
 
   This example code is in the public domain.
 
-  http://www.arduino.cc/en/Tutorial/ButtonStateChange
+  https://www.arduino.cc/en/Tutorial/BuiltInExamples/StateChangeDetection
 */
 
 // this constant won't change:


### PR DESCRIPTION
Changing Tutorial's link
Inside the comment section

From (broken)  http://www.arduino.cc/en/Tutorial/ButtonStateChange
to https://www.arduino.cc/en/Tutorial/BuiltInExamples/StateChangeDetection