### PR TITLE
Add missing tutorial links to examples

### DIFF
--- a/examples/04.Communication/MultiSerial/MultiSerial.ino
+++ b/examples/04.Communication/MultiSerial/MultiSerial.ino
@@ -17,6 +17,8 @@
   by Arturo Guadalupi
 
   This example code is in the public domain.
+
+  https://www.arduino.cc/en/Tutorial/BuiltInExamples/MultiSerialMega
 */
 
 

--- a/examples/04.Communication/ReadASCIIString/ReadASCIIString.ino
+++ b/examples/04.Communication/ReadASCIIString/ReadASCIIString.ino
@@ -17,6 +17,8 @@
   by Arturo Guadalupi
 
   This example code is in the public domain.
+
+  https://www.arduino.cc/en/Tutorial/BuiltInExamples/ReadASCIIString
 */
 
 // pins for the LEDs:

--- a/examples/04.Communication/SerialPassthrough/SerialPassthrough.ino
+++ b/examples/04.Communication/SerialPassthrough/SerialPassthrough.ino
@@ -20,6 +20,8 @@
 
   created 23 May 2016
   by Erik Nyquist
+
+  https://www.arduino.cc/en/Tutorial/BuiltInExamples/SerialPassthrough
 */
 
 void setup() {


### PR DESCRIPTION
Fixes https://github.com/arduino/arduino-examples/issues/31