### PR TITLE
Expand compilation workflow's paths filter to cover more irrelevant files

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -16,13 +16,25 @@ name: Compile Examples
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/compile-examples.yml"
-      - "examples/**"
+    paths-ignore:
+      - "**"
+      - "!.github/workflows/compile-examples.ya?ml"
+      - "!examples/**"
+      - "**.adoc"
+      - "**.jpg"
+      - "**.md"
+      - "**.png"
+      - "**.txt"
   push:
-    paths:
-      - ".github/workflows/compile-examples.yml"
-      - "examples/**"
+    paths-ignore:
+      - "**"
+      - "!.github/workflows/compile-examples.ya?ml"
+      - "!examples/**"
+      - "**.adoc"
+      - "**.jpg"
+      - "**.md"
+      - "**.png"
+      - "**.txt"
   # Scheduled trigger checks for breakage caused by changes to external resources (libraries, platforms)
   schedule:
     # run every Tuesday at 3 AM UTC


### PR DESCRIPTION
The [`paths` filter](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths) is used to make GitHub Actions workflows more efficient and contributor friendly by preventing pointless
workflow runs from happening when only irrelevant files were modified.