### PR TITLE
Use modern board-specific Mbed OS Boards platforms

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -120,13 +120,13 @@ jobs:
             starter-kit: false
             tone: true
             pulsein: true
-          - fqbn: arduino:mbed:nano33ble
+          - fqbn: arduino:mbed_nano:nano33ble
             usb: false
             serial1: true
             starter-kit: false
             tone: true
             pulsein: true
-          - fqbn: arduino:mbed:envie_m7
+          - fqbn: arduino:mbed_portenta:envie_m7
             usb: false
             serial1: true
             starter-kit: false


### PR DESCRIPTION
Since the time the workflow was written, the "Arduino Mbed OS Boards" platform [was split](https://github.com/arduino/ArduinoCore-mbed/releases/tag/2.0.0) into a variant for each of the boards "families" supported by that platform. The benefit of this split is a reduction of installation and compilation times. The previous `arduino:mbed` platform is still available to ease the transition to the new platforms, but it is deprecated.