### PR TITLE
Use FQBN for sketch compilation workflow job names

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -48,6 +48,7 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.board.fqbn }}
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
The "Compile Examples" workflow used to do a "smoke test" sketch compilation CI check uses a job matrix to compile the
sketches for all boards of interest.

By default, the matrix job is named by the matrix element for that job. This element includes board data used to make
board-specific job customizations. That attribute data makes the job name, which is used to identify it in the checks
status UI and workflow logs, fairly cryptic. The only information of interest to a human identifying the job is the FQBN.
Defining a custom job name overrides the default job naming behavior.