### PR TITLE
ArduinoISP: Add hint MISO/MOSI -> CIPO/COPI

### DIFF
--- a/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
+++ b/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
@@ -3,7 +3,8 @@
 // If you require a license, see
 // https://opensource.org/licenses/bsd-license.php
 //
-// Please note that this sketch still uses MISO/MOSI instead of CIPO/COPI.
+// Note that this sketch refers to the SPI bus pins using the legacy MISO/MOSI
+// names rather than the modern CIPO/COPI names.
 // For further details, see https://docs.arduino.cc/learn/communication/spi
 //
 // This sketch turns the Arduino into a AVRISP using the following Arduino pins:

--- a/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
+++ b/examples/11.ArduinoISP/ArduinoISP/ArduinoISP.ino
@@ -3,6 +3,9 @@
 // If you require a license, see
 // https://opensource.org/licenses/bsd-license.php
 //
+// Please note that this sketch still uses MISO/MOSI instead of CIPO/COPI.
+// For further details, see https://docs.arduino.cc/learn/communication/spi
+//
 // This sketch turns the Arduino into a AVRISP using the following Arduino pins:
 //
 // Pin 10 is used to reset the target microcontroller.


### PR DESCRIPTION
The Arduino documentation uses the new CIPO/COPI terminology while the whole arduino core still uses the old MISO/MOSI.  While I thought about changing everything in the arduino cores, this would break many old sketches so I figuered adding a hint is the way to go. Also, only changing terminology in this sketch doesn't work for consistency reasons, eg. beginning in line 106.