### PR TITLE
Only delay after serial output in "Knock"

### DIFF
--- a/examples/06.Sensors/Knock/Knock.ino
+++ b/examples/06.Sensors/Knock/Knock.ino
@@ -49,6 +49,6 @@ void loop() {
     digitalWrite(ledPin, ledState);
     // send the string "Knock!" back to the computer, followed by newline
     Serial.println("Knock!");
+    delay(100);  // delay to avoid overloading the serial port buffer
   }
-  delay(100);  // delay to avoid overloading the serial port buffer
 }


### PR DESCRIPTION
The "Knock" sketch polls the voltage output from a piezo disc to detect the vibrations associated with a knock.

The duration of vibrations from a single knock is likely to significantly exceed the unchecked polling interval. This would result in a single knock producing multiple detections, and thus multiple prints to `Serial`. In order to avoid this, a "debouncing" delay was added to the sketch.

Previously the delay was positioned in the outer scope of the `loop` function, which caused it to always affect the polling interval. This caused the sketch to miss the detection of knocks that produced vibrations that only occurred during that unnecessary delay. The problem is fixed by moving the delay inside the knock detection conditional block, so that debouncing is only done when actually needed.

---

Originally reported at https://github.com/arduino/docs-content/issues/2159