### PR TITLE
Document incomplete nature of "p08_DigitalHourglass"

### DIFF
--- a/examples/10.StarterKit_BasicKit/p08_DigitalHourglass/p08_DigitalHourglass.ino
+++ b/examples/10.StarterKit_BasicKit/p08_DigitalHourglass/p08_DigitalHourglass.ino
@@ -10,6 +10,9 @@
   - six LEDs
   - tilt switch
 
+  NOTE: This sketch is intentionally incomplete. Make sure to add your own code
+  for whatever you want to happen at the end of the hour.
+
   created 13 Sep 2012
   by Scott Fitzgerald
 
@@ -55,6 +58,7 @@ void loop() {
 
     if (led == 7) {
       // the hour is up
+      // add your indicator code here
     }
   }
 


### PR DESCRIPTION
The sketches under the `10.StarterKit_BasicKit` folder are provided to accompany the **Arduino Projects Book** of the [**Arduino Starter Kit**](https://store.arduino.cc/products/arduino-starter-kit-multi-language). The **Arduino Projects Book** explains the code of these sketches and gives instructions for their usage.

In addition to owners of the **Arduino Starter Kit**, other users might use these prominent sketches as learning references. Those users won't have the context that would be provided by the **Arduino Projects Book**. For this reason, explanatory comments have been added to these sketches.

The "**p08_DigitalHourglass**" sketch is unique in that it is intentionally left incomplete. The **Arduino Projects Book** instructs the user to add their own code to indicate the completion of the timer. It is important that this code be added, since the incomplete code does not halt the LED control code at the end of the hour. If the incomplete code is used unchanged, the LED control code will call `digitalWrite` on additional pins.

Previously, the comments in the sketch did not explain the incomplete nature of the sketch. Comments are hereby added to explain this to users who don't have the context provided by the **Arduino Projects Book**.

---

Mitigates https://github.com/arduino/arduino-examples/issues/83